### PR TITLE
Cosmetic changes to buttons and footer

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -26,7 +26,7 @@ body_class: pages-home
                 <span>
                   Ik ben geïnteresseerd
                 </span>
-                <i class="fas fa-chevron-right"></i>
+                <i class="fas fa-chevron-right chev-r"></i>
               <% end %>
             </div>
           </div>
@@ -51,7 +51,7 @@ body_class: pages-home
             <span>
               Ik ben geïnteresseerd
             </span>
-            <i class="fas fa-chevron-right"></i>
+            <i class="fas fa-chevron-right chev-r"></i>
           <% end %>
         </div>
       </div>

--- a/source/shared/_footer.html.erb
+++ b/source/shared/_footer.html.erb
@@ -1,7 +1,9 @@
 <footer>
   <div class="container">
     <div class="row">
-      <div class="col-12 col-lg-8">
+      <!-- AShergill 20-June-2020: added the bootstrap col specs for small and large screens to make
+            sure that the logo didn't appear underneath the ul -->
+      <div class="col-xs-8 col-lg-8">
         <ul class="list-unstyled">
           <li>
             <span>
@@ -36,7 +38,9 @@
           </li>
         </ul>
       </div>
-      <div class="col-lg-4">
+      <!-- AShergill 20-June-2020: added the bootstrap col specs for small and large screens to make
+            sure that the logo didn't appear underneath the ul -->
+      <div class="col-xs-4 col-lg-4">
         <div class="logo-wrapper">
           <%= image_tag 'logo-white.svg' %>
         </div>
@@ -54,7 +58,7 @@
             <% end %>
           </div>
           <p class="copyright">
-            Copyright 2019 The Conversation Playground
+            Copyright 2020 The Conversation Playground
           </p>
         </div>
       </div>

--- a/source/shared/_navbar.html.erb
+++ b/source/shared/_navbar.html.erb
@@ -24,7 +24,7 @@
     <span>
       Contact
     </span>
-    <i class="fas fa-chevron-right"></i>
+    <i class="fas fa-chevron-right chev-r"></i>
     <% end %>
   </div>
 </div>
@@ -55,7 +55,7 @@
     <span>
       Contact
     </span>
-    <i class="fas fa-chevron-right"></i>
+    <i class="fas fa-chevron-right chev-r"></i>
     <% end %>
   </div>
 </div>

--- a/source/stylesheets/components/_buttons.scss
+++ b/source/stylesheets/components/_buttons.scss
@@ -5,10 +5,15 @@
   margin: 10px 0;
   display: inline-block;
   border: none;
+  /*AShergill 21-June-2020: hover over causes button to darken*/
+  transition: .5s;
   &:hover, &:active, &:visited, &:focus {
     text-decoration: none;
     color: white;
+    font-weight: 515;
+    background-color: #1ea4c9;
   }
+
 }
 
 .bubble-button-blue {
@@ -72,9 +77,11 @@
   align-items: center;
   color: $blue;
   text-decoration: none;
+  transition: 1s;
   &:hover, &:active, &:visited, &:focus {
     text-decoration: none;
     color: $blue;
+    transform: translate(-0.5em);
   }
   .btn-previous {
     margin-right: 10px;

--- a/source/stylesheets/components/_footer.scss
+++ b/source/stylesheets/components/_footer.scss
@@ -1,3 +1,4 @@
+
 footer {
   min-height: 180px;
   width: 100vw;
@@ -5,14 +6,24 @@ footer {
   color: white;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: flex-end;
+ 
+  /*AShergill 20-June-2020: added code to make sure the footer is spread out across whole
+  screen at all times... even on a smal screen */
+  .container{
+    width: 100%;
+  }
+
   .logo-wrapper {
     display: flex;
     justify-content: flex-end;
+
     img {
       width: 150px;
     }
   }
+
+  
 
   .social-media {
     a {
@@ -26,7 +37,7 @@ footer {
     height: 100%;
     display: flex;
     flex-direction: column;
-    justify-content: center;
+    justify-content: flex-start;
   }
   li {
     font-size: 14px;
@@ -45,6 +56,7 @@ footer {
       color: white;
     }
   }
+
 }
 
 footer .copyright {
@@ -75,27 +87,4 @@ footer .credits {
   }
 }
 
-@media (max-width: 500px) {
-  footer { 
-    ul {
-      margin-top: 20px;
-      li {
-        margin-bottom: 10px;
-      }
-    }
-    .logo-wrapper {
-      justify-content: flex-start;
-      img {
-        margin-left: -20px;
-      }
-    }
-  }
-}
 
-
-@media (min-width: 768px) {
-  footer .logo-wrapper img {
-    margin-right: -50px;
-
-  }
-}

--- a/source/stylesheets/components/_navbar.scss
+++ b/source/stylesheets/components/_navbar.scss
@@ -13,6 +13,17 @@
   align-items: center;
 }
 
+/* AShergill 22-June-2020: move the right chevron down slightly because it's not aligned with
+   the text just for these two buttons*/
+.inschrijven-chev{
+  padding-top: 5px;
+}
+
+.workshop-max-width{
+  width: 170px;
+}
+
+
 .navbar-custom-center li {
   display: inline-block;
   padding: 0 20px;
@@ -51,11 +62,28 @@
   color: white;
   border: 2px solid $red;
   padding: 5px 10px;
+  transition: .5s;
+  /* AShergill 21-June-2020: added class to move chevrons when hover over*/
+  .chev-r
+  {
+    transition: .7s;
+  }
+
   &:hover, &:active, &:visited, &:focus {
     text-decoration: none;
     color: white;
+    .chev-r{
+      transform: translate(0.3em);
+    } 
+ 
+    &:hover{
+      background-color: #e43353;
+      border: 2px solid #e43353;
+    }
   }
 }
+
+
 
 #sticky-nav.hidden-up {
   top: -66px;
@@ -86,7 +114,6 @@
     width: 150px;
   }
 }
-
 
 @media (min-width: 768px) {
   .navbar-custom .logo img {

--- a/source/templates/_coding_bootcamp.html.erb
+++ b/source/templates/_coding_bootcamp.html.erb
@@ -23,7 +23,7 @@
            <span>
              Aanmelden
            </span>
-           <i class="fas fa-chevron-right"></i>
+           <i class="fas fa-chevron-right chev-r"></i>
         <% end %>
     </p>
     <p>
@@ -168,7 +168,7 @@
   Een volledige Bootcamp bestaat uit <strong>4 workshops</strong> van elk <strong>3 uur</strong>. 
   We hebben per workshop een minimum van 6 kinderen nodig om voldoende interactie te stimuleren. 
   Als maximum geldt een aantal van <strong>10 kinderen</strong>: dit om ieder kind voldoende 
-  persoonlijke aandacht te kunnen geven. De totale kosten per kind bedragen <strong>€285</strong> (inclusief aankoop micro:bit).
+  persoonlijke aandacht te kunnen geven. De totale kosten per kind bedragen <strong>€228</strong> (inclusief aankoop micro:bit).
 </p>
 <p>
   Het Bootcamp loopt vier dagen achter elkaar van 6 juli t/m 9 juli. 
@@ -206,7 +206,7 @@
            <span>
              Niveau bepalen
            </span>
-           <i class="fas fa-chevron-right"></i>
+           <i class="fas fa-chevron-right chev-r"></i>
         <% end %>
   <br>
   <br>

--- a/source/templates/_coding_course.html.erb
+++ b/source/templates/_coding_course.html.erb
@@ -183,7 +183,7 @@
            <span>
              Niveau bepalen
            </span>
-           <i class="fas fa-chevron-right"></i>
+           <i class="fas fa-chevron-right chev-r"></i>
         <% end %>
   <br>
   <br>
@@ -205,6 +205,6 @@
            <span>
              Ik ben geïnteresseerd
            </span>
-           <i class="fas fa-chevron-right"></i>
+           <i class="fas fa-chevron-right chev-r"></i>
         <% end %>
 </p>

--- a/source/templates/_company_workshop.html.erb
+++ b/source/templates/_company_workshop.html.erb
@@ -90,7 +90,7 @@
            <span>
              Niveau bepalen
            </span>
-           <i class="fas fa-chevron-right"></i>
+           <i class="fas fa-chevron-right chev-r"></i>
         <% end %>
   <br>
   <br>
@@ -111,6 +111,6 @@
      <span>
        Ik ben geïnteresseerd
      </span>
-    <i class="fas fa-chevron-right"></i>
+    <i class="fas fa-chevron-right chev-r"></i>
   <% end %>
 </p>

--- a/source/templates/_conversation.html.erb
+++ b/source/templates/_conversation.html.erb
@@ -110,7 +110,7 @@
            <span>
              Niveau bepalen
            </span>
-           <i class="fas fa-chevron-right"></i>
+           <i class="fas fa-chevron-right chev-r"></i>
         <% end %>
   <br>
   <br>
@@ -132,6 +132,6 @@
      <span>
        Ik ben geïnteresseerd
      </span>
-    <i class="fas fa-chevron-right"></i>
+    <i class="fas fa-chevron-right chev-r"></i>
   <% end %>
 </p>

--- a/source/templates/_conversation_workshop.html.erb
+++ b/source/templates/_conversation_workshop.html.erb
@@ -22,7 +22,7 @@
            <span>
              Aanmelden
            </span>
-           <i class="fas fa-chevron-right"></i>
+           <i class="fas fa-chevron-right chev-r"></i>
         <% end %>
     </p>
     <p>
@@ -125,7 +125,7 @@
            <span>
              Niveau bepalen
            </span>
-           <i class="fas fa-chevron-right"></i>
+           <i class="fas fa-chevron-right chev-r"></i>
         <% end %>
   <br>
   <br>

--- a/source/templates/_teachers_workshop.html.erb
+++ b/source/templates/_teachers_workshop.html.erb
@@ -87,7 +87,7 @@
            <span>
              Niveau bepalen
            </span>
-           <i class="fas fa-chevron-right"></i>
+           <i class="fas fa-chevron-right chev-r"></i>
         <% end %>
   <br>
   <br>
@@ -109,6 +109,6 @@
      <span>
        Ik ben geïnteresseerd
      </span>
-    <i class="fas fa-chevron-right"></i>
+    <i class="fas fa-chevron-right chev-r"></i>
   <% end %>
 </p>

--- a/source/templates/workshop.html.erb
+++ b/source/templates/workshop.html.erb
@@ -92,11 +92,12 @@ title: The Conversation Playground - Workshops
             <% end %>
           </ul>
           <!-- AShergill 31-May-2020: put in a button with a chevron -->
-          <% link_to "/#contact-section", class: 'navbar-custom-item-extra', "data-target" => "#contact-section" do %>
+          <% link_to "/#contact-section", class: 'navbar-custom-item-extra workshop-max-width', "data-target" => "#contact-section" do %>
              <span>
                Inschrijven
              </span>
-             <i class="fas fa-chevron-right"></i>
+             <!-- AShergill 21-June-2020: added the id to move the chevron when hover over button -->
+             <i class="fas fa-chevron-right chev-r inschrijven-chev"></i>
           <% end %>
       </div>
       </div>
@@ -175,11 +176,11 @@ title: The Conversation Playground - Workshops
             <% end %>
           </ul>
           <!-- AShergill 31-May-2020: put in a button with a chevron -->
-          <% link_to "/#contact-section", class: 'navbar-custom-item-extra', "data-target" => "#contact-section" do %>
+          <% link_to "/#contact-section", class: 'navbar-custom-item-extra workshop-max-width', "data-target" => "#contact-section" do %>
              <span>
                Inschrijven
              </span>
-             <i class="fas fa-chevron-right"></i>
+             <i class="fas fa-chevron-right chev-r inschrijven-chev"></i>
           <% end %>
         </div>
       </div>


### PR DESCRIPTION
1. Fixed: footer looked a mess on smaller screens, the logo was under the email addresses and social media links 
2. hover over buttons now causes then to darken and chevron moves to the right
3. on the workshop pages, the inschrijven button under the card was stretching across the width of the card.  The width of this button has been hard-coded to 170px
4. Price of coding bootcamp in the main text changed to 228
5. Changed copyright date in footer to 2020.