### PR TITLE
Fixed alignment issues on smaller screens

### DIFF
--- a/source/stylesheets/components/_footer.scss
+++ b/source/stylesheets/components/_footer.scss
@@ -14,16 +14,10 @@ footer {
     width: 100%;
   }
 
+  /*AShergill 24-June-2020: only display the logo on larger screens */
   .logo-wrapper {
-    display: flex;
-    justify-content: flex-end;
-
-    img {
-      width: 150px;
-    }
+    display: none;
   }
-
-  
 
   .social-media {
     a {
@@ -87,4 +81,14 @@ footer .credits {
   }
 }
 
+/*AShergill 24-June-2020: only display the logo on larger screens */
+@media (min-width: 700px){
+  footer .logo-wrapper {
+    display: flex;
+    justify-content: flex-end;
 
+    img {
+      width: 150px;
+    }
+  }
+}

--- a/source/stylesheets/components/_team.scss
+++ b/source/stylesheets/components/_team.scss
@@ -72,6 +72,7 @@
   text-decoration: underline;
 }
 
+
 @media (max-width: 768px) {
   .team-wrapper {
     padding-bottom: 100px;
@@ -86,6 +87,12 @@
     margin-bottom: 40px;
     text-align: left;
   }
+
+  /*AShergill 24-June-2020: center the image on smaller devices*/
+  .team-bio-head{
+    margin-left: 18%;
+  }
+  
 }
 
 @media (min-width: 768px) {

--- a/source/stylesheets/components/_workshops.scss
+++ b/source/stylesheets/components/_workshops.scss
@@ -23,6 +23,8 @@
 .workshop-illustration {
   margin: 0 auto;
   display: block;
+  /*AShergill 24-June-2020: illustration width set to small for small screens */
+  width: 300px;
 }
 
 .side-info-container ul {
@@ -66,13 +68,23 @@
   color: white;
 }
 
+
+@media (min-width:500px) {
+  /*AShergill 24-June-2020: illustration width set to 400px for bigger screens */
+  .workshop-illustration {
+    width: 400px;
+  }
+}
+
 @media (min-width: 900px) {
   .side-info-container {
     width: 25%;
     position: sticky;
     top: 20px;
-  }
+  } 
 }
+
+
 
 @media (max-width: 900px) {
   .side-info-container {
@@ -80,3 +92,4 @@
     padding-left: 15px;
   }
 }
+

--- a/source/templates/_coding_bootcamp.html.erb
+++ b/source/templates/_coding_bootcamp.html.erb
@@ -8,8 +8,8 @@
     </p>
   </div>
   <div class="col-xs-12 col-lg-4 visible-xs visible-md visible-sm">
-    <!-- AShergill 10-June-2020 resized the image -->
-    <%= image_tag workshop["image"], width: 400, class: "workshop-illustration" %>
+    <!-- AShergill 24-June-2020 moved image width to css -->
+    <%= image_tag workshop["image"], class: "workshop-illustration" %>
   </div>
   
   <div class="col-xs-12 col-lg-7">
@@ -63,8 +63,8 @@
     </ul>
   </div>
   <div class="col-xs-12 col-lg-4 hidden-xs hidden-md hidden-sm">
-    <!-- AShergill 10-June-2020 resized the image -->
-    <%= image_tag workshop["image"], width: 400, class: "workshop-illustration" %>
+    <!-- AShergill 24-June-2020 moved image width to css -->
+    <%= image_tag workshop["image"], class: "workshop-illustration" %>
   </div>
 </div>
 <p>

--- a/source/templates/_coding_course.html.erb
+++ b/source/templates/_coding_course.html.erb
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="col-xs-12 col-lg-4 visible-xs visible-md visible-sm">
-    <!-- AShergill 10-June-2020 resized the image -->
-    <%= image_tag workshop["image"], width: 400, class: "workshop-illustration" %>
+    <!-- AShergill 24-June-2020 moved image width to css -->
+    <%= image_tag workshop["image"], class: "workshop-illustration" %>
   </div>
   <div class="col-xs-12 col-lg-7">
     <h3>
@@ -48,8 +48,8 @@
     </ul>
   </div>
   <div class="col-xs-12 col-lg-4 hidden-xs hidden-md hidden-sm">
-    <!-- AShergill 10-June-2020 resized the image -->
-    <%= image_tag workshop["image"], width: 400, class: "workshop-illustration" %>
+    <!-- AShergill 24-June-2020 moved image width to css -->
+    <%= image_tag workshop["image"], class: "workshop-illustration" %>
   </div>
 </div>
 <p>

--- a/source/templates/_company_workshop.html.erb
+++ b/source/templates/_company_workshop.html.erb
@@ -1,8 +1,8 @@
 <!-- AShergill 10-June-2020 - new workshop added -->
 <div class="row">
   <div class="col-xs-12 col-lg-4 visible-xs visible-md visible-sm">
-    <!-- AShergill 10-June-2020 resized the image -->
-    <%= image_tag workshop["image"], width: 400, class: "workshop-illustration" %>
+    <!-- AShergill 24-June-2020 moved image width to css -->
+    <%= image_tag workshop["image"], class: "workshop-illustration" %>
   </div>
   <div class="col-xs-12 col-lg-7">
     <h3>
@@ -38,7 +38,8 @@
     </ul>
   </div>
     <div class="col-xs-12 col-lg-4 hidden-xs hidden-md hidden-sm">
-      <%= image_tag workshop["image"], width: 400, class: "workshop-illustration" %>
+      <!-- AShergill 24-June-2020 moved image width to css -->
+      <%= image_tag workshop["image"], class: "workshop-illustration" %>
   </div>
 </div>
     <p>

--- a/source/templates/_conversation.html.erb
+++ b/source/templates/_conversation.html.erb
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="col-xs-12 col-lg-4 visible-xs visible-md visible-sm">
-    <!-- AShergill 10-June-2020 resized the image -->
-    <%= image_tag workshop["image"], width: 400, class: "workshop-illustration" %>
+    <!-- AShergill 24-June-2020 moved image width to css -->
+    <%= image_tag workshop["image"], class: "workshop-illustration" %>
   </div>
   <div class="col-xs-12 col-lg-7">
     <h3>
@@ -47,8 +47,8 @@
     </p>
   </div>
   <div class="col-xs-12 col-lg-4 hidden-xs hidden-md hidden-sm">
-    <!-- AShergill 10-June-2020 resized the image -->
-    <%= image_tag workshop["image"], width: 400, class: "workshop-illustration" %>
+    <!-- AShergill 24-June-2020 moved image width to css -->
+    <%= image_tag workshop["image"], class: "workshop-illustration" %>
   </div>
 </div>
 <p>

--- a/source/templates/_conversation_workshop.html.erb
+++ b/source/templates/_conversation_workshop.html.erb
@@ -8,8 +8,8 @@
     </p>
   </div>
   <div class="col-xs-12 col-lg-4 visible-xs visible-md visible-sm">
-    <!-- AShergill 10-June-2020 resized the image -->
-    <%= image_tag workshop["image"], width: 400, class: "workshop-illustration" %>
+    <!-- AShergill 24-June-2020 moved image width to css -->
+    <%= image_tag workshop["image"], class: "workshop-illustration" %>
   </div>
   <div class="col-xs-12 col-lg-7">
     <h3>
@@ -56,8 +56,8 @@
     </ul>
   </div>
   <div class="col-xs-12 col-lg-4 hidden-xs hidden-md hidden-sm">
-    <!-- AShergill 10-June-2020 resized the image -->
-    <%= image_tag workshop["image"], width: 400, class: "workshop-illustration" %>
+    <!-- AShergill 24-June-2020 moved image width to css -->
+    <%= image_tag workshop["image"], class: "workshop-illustration" %>
   </div>
 </div>
 <p>

--- a/source/templates/_teachers_workshop.html.erb
+++ b/source/templates/_teachers_workshop.html.erb
@@ -1,8 +1,8 @@
 <!-- AShergill 10-June-2020 - new workshop added -->
 <div class="row">
   <div class="col-xs-12 col-lg-4 visible-xs visible-md visible-sm">
-    <!-- AShergill 10-June-2020 resized the image -->
-    <%= image_tag workshop["image"], width: 400, class: "workshop-illustration" %>
+    <!-- AShergill 24-June-2020 moved image width to css -->
+    <%= image_tag workshop["image"], class: "workshop-illustration" %>
   </div>
   <div class="col-xs-12 col-lg-7">
     <h3>
@@ -47,7 +47,8 @@
     </p>
   </div>
   <div class="col-xs-12 col-lg-4 hidden-xs hidden-md hidden-sm">
-    <%= image_tag workshop["image"], width: 400, class: "workshop-illustration" %>
+    <!-- AShergill 24-June-2020 moved image width to css -->
+    <%= image_tag workshop["image"], class: "workshop-illustration" %>
   </div>
 </div>
 <p>


### PR DESCRIPTION
1. all workshops pages were too wide for smartphone screens because i made the illustration width 400px in previous release.  This has been changed to be more responsive.
2. removed the company logo from the footer on smaller screens because it messes the footer up.
3. centered the team member profile picture on smaller screens